### PR TITLE
[FIX#33483] Ajout d'une majuscule au flag `printflag`

### DIFF
--- a/src/SPrinter.php
+++ b/src/SPrinter.php
@@ -26,7 +26,7 @@ class SPrinter
         $print_params = [
             "template"   => $template,
             "data"       => $data,
-            "printflag"  => $print_flag
+            "printFlag"  => $print_flag
         ];
         if ($opt) {
             $print_params = array_merge($print_params, $opt);


### PR DESCRIPTION
Le nom du flag n'était pas le bon.